### PR TITLE
Handle NaN correctly in NumberValue.

### DIFF
--- a/src/main/as/react/AbstractValue.as
+++ b/src/main/as/react/AbstractValue.as
@@ -90,7 +90,7 @@ public /*abstract*/ class AbstractValue extends Reactor
     protected function updateAndNotify (value :Object, force :Boolean = true) :Object {
         checkMutate();
         var ovalue :Object = updateLocal(value);
-        if (force || value != ovalue) {
+        if (force || !valuesAreEqual(value, ovalue)) {
             emitChange(value, ovalue);
         }
         return ovalue;
@@ -116,6 +116,14 @@ public /*abstract*/ class AbstractValue extends Reactor
      */
     protected function updateLocal (value :Object) :Object {
         throw new IllegalOperationError();
+    }
+
+    /**
+     * Override to customize the comparison done in updateAndNotify to decide if an update will
+     * be performed if a force is not requested.
+     */
+    protected function valuesAreEqual (value1 :Object, value2 :Object) :Boolean {
+        return value1 == value2;
     }
 
     protected static function CHANGE (l :RListener, value :Object, oldValue :Object, _ :Object) :void {

--- a/src/main/as/react/NumberValue.as
+++ b/src/main/as/react/NumberValue.as
@@ -45,6 +45,10 @@ public class NumberValue extends AbstractValue
         return oldValue;
     }
 
+    override protected function valuesAreEqual (value1 :Object, value2 :Object) :Boolean {
+        return value1 == value2 || (isNaN(Number(value1)) && isNaN(Number(value2)));
+    }
+
     protected var _value :Number;
 }
 }


### PR DESCRIPTION
If the value is set to NaN and the value is already NaN and a force is not requested, an update
dispatch should not occur. In Flash, NaN is always not equal to anything, including NaN, so a more
complex comparison is required.
